### PR TITLE
Revert "Bump just-the-docs from 0.6.1 to 0.9.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 gem "jekyll", "~> 4.3.2" # installed by `gem jekyll`
 # gem "webrick"        # required when using Ruby >= 3 and Jekyll <= 4.2.2
 
-gem "just-the-docs", "0.9.0" # pinned to the current release
+gem "just-the-docs", "0.6.1" # pinned to the current release
 # gem "just-the-docs"        # always download the latest release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,19 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
-    bigdecimal (3.1.8)
+    addressable (2.8.5)
+      public_suffix (>= 2.0.2, < 6.0)
     colorator (1.1.0)
-    concurrent-ruby (1.3.4)
+    concurrent-ruby (1.2.2)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.15.5)
     forwardable-extended (2.6.0)
-    google-protobuf (4.27.3-x86_64-linux)
-      bigdecimal
-      rake (>= 13)
+    google-protobuf (3.24.2-x86_64-linux)
     http_parser.rb (0.8.0)
-    i18n (1.14.5)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     jekyll (4.3.2)
       addressable (~> 2.4)
@@ -42,7 +39,7 @@ GEM
       jekyll (>= 3.8, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    just-the-docs (0.9.0)
+    just-the-docs (0.6.1)
       jekyll (>= 3.8.5)
       jekyll-include-cache
       jekyll-seo-tag (>= 2.0)
@@ -52,27 +49,25 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.4)
-    listen (3.9.0)
+    listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (6.0.1)
-    rake (13.2.1)
+    public_suffix (5.0.3)
+    rake (13.0.6)
     rb-fsevent (0.11.2)
-    rb-inotify (0.11.1)
+    rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.3.6)
-      strscan
-    rouge (4.3.0)
+    rexml (3.2.6)
+    rouge (4.1.3)
     safe_yaml (1.0.5)
-    sass-embedded (1.77.8-x86_64-linux-gnu)
-      google-protobuf (~> 4.26)
-    strscan (3.1.0)
+    sass-embedded (1.66.1-x86_64-linux-gnu)
+      google-protobuf (~> 3.23)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    unicode-display_width (2.5.0)
+    unicode-display_width (2.4.2)
     webrick (1.8.1)
 
 PLATFORMS
@@ -80,7 +75,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (~> 4.3.2)
-  just-the-docs (= 0.9.0)
+  just-the-docs (= 0.6.1)
 
 BUNDLED WITH
    2.3.26


### PR DESCRIPTION
Reverts open-genome/open-genome.github.io#2